### PR TITLE
Cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /*.suo
 /RemoteSystemsTempFiles
 /scg3_demo
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /RemoteSystemsTempFiles
 /scg3_demo
 /build
+/build-output
+/cmake-build-debug
+/.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+# CMake configuration based on https://github.com/pablospe/cmake-example-library
+
+cmake_minimum_required(VERSION 2.6)
+
+# Project name
+project (scg3)
+set(LIBRARY_NAME scg3)
+set(LIBRARY_FOLDER scg3)
+
+# Use C++ 11
+set(CMAKE_CXX_STANDARD 11)
+
+# Set variables
+include(${CMAKE_SOURCE_DIR}/cmake/SetEnv.cmake)
+
+# Check for required packages
+find_package(OpenGL REQUIRED)
+find_package(GLUT REQUIRED)
+find_package(X11 REQUIRED)
+find_package(glfw3 REQUIRED)
+
+# Libraries
+set(LIBS ${OPENGL_LIBRARIES} ${GLFW_LIBRARIES} ${X11_LIBRARIES} ${GLUT_LIBRARY} glfw Xrandr Xxf86vm)
+
+# Library sources
+add_subdirectory (scg3)
+
+# Example
+add_subdirectory (scg3_example)
+
+# Install targets
+include(${CMAKE_SOURCE_DIR}/cmake/InstallConfig.cmake)

--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ cmake -DCMAKE_INSTALL_PREFIX=../build-output ..
 make install -j8   # replace 8 with CPU core count
 ```
 
-In case you want to install the scg3 library globally into your system, use `cmake -DCMAKE_INSTALL_PREFIX=./usr ..` and `sudo make install -jX` instead.
+In case you want to install the scg3 library globally into your system, use `cmake -DCMAKE_INSTALL_PREFIX=/usr ..` and `sudo make install -jX` instead.
 Uninstallation can be done using `sudo make uninstall`.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Prerequisites:
 
 #### Building using CMake on Linux
 
-This project contains CMake files to build the project from the command line or import into into IDEs like CLion. (Only tested on Linux!)
+This project contains CMake files to build the project from the command line or import it into IDEs like CLion. (Only tested on Linux)
 
-After navigating into the root directory of the project, you can build the library and example code using these commands:
+After navigating to the root directory of the project, you can build the library and example code using these commands:
 
 ```
 mkdir build

--- a/README.md
+++ b/README.md
@@ -33,3 +33,19 @@ Prerequisites:
 * C++11 compiler, e.g., GCC 4.5, LLVM/Clang 3.1, Visual C++ 2010 (or higher)
 * OpenGL 3.2 graphics driver (or higher)
 * GLFW 3.2.0 (or higher), cf. http://www.glfw.org/
+
+#### Building using CMake on Linux
+
+This project contains CMake files to build the project from the command line or import into into IDEs like CLion. (Only tested on Linux!)
+
+After navigating into the root directory of the project, you can build the library and example code using these commands:
+
+```
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=../build-output ..
+make install -j8   # replace 8 with CPU core count
+```
+
+In case you want to install the scg3 library globally into your system, use `cmake -DCMAKE_INSTALL_PREFIX=./usr ..` and `sudo make install -jX` instead.
+Uninstallation can be done using `sudo make uninstall`.

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,13 @@
+# - Config file for '@PROJECT_NAME@' package
+# It defines the following variables
+#  @PROJECT_NAME_UPPERCASE@_INCLUDE_DIRS - include directories
+#  @PROJECT_NAME_UPPERCASE@_LIBRARIES    - libraries to link against
+
+# Include directory
+set(@PROJECT_NAME_UPPERCASE@_INCLUDE_DIRS "@INSTALL_INCLUDE_DIR@")
+
+# Import the exported targets
+include("@INSTALL_CMAKE_DIR@/@PROJECT_NAME@Targets.cmake")
+
+# Set the expected library variable
+set(@PROJECT_NAME_UPPERCASE@_LIBRARIES @LIBRARY_NAME@)

--- a/cmake/ConfigVersion.cmake.in
+++ b/cmake/ConfigVersion.cmake.in
@@ -1,0 +1,22 @@
+# FIND_PACKAGE() searches for a <package>Config.cmake file and an associated
+# <package>Version.cmake file, which it loads to check the version number,
+# when a version has been specified in the find_package() call,
+# e.g. find_package(Foo 1.0.0).
+#
+# This file can be used with configure_file() to generate such a file for a
+# project with very basic logic.
+#
+# It sets PACKAGE_VERSION_EXACT if the current version string and the requested
+# version string are exactly the same and it sets PACKAGE_VERSION_COMPATIBLE
+# if the current version is >= requested version.
+
+set(PACKAGE_VERSION @PROJECT_VERSION@)
+
+IF("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
+   set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+   set(PACKAGE_VERSION_COMPATIBLE TRUE)
+   if("${PACKAGE_FIND_VERSION}" STREQUAL "${PACKAGE_VERSION}")
+      set(PACKAGE_VERSION_EXACT TRUE)
+   endif()
+endif()

--- a/cmake/InstallConfig.cmake
+++ b/cmake/InstallConfig.cmake
@@ -1,0 +1,25 @@
+# This "exports" all targets which have been put into the export set
+install(EXPORT ${PROJECT_EXPORT}
+  DESTINATION ${INSTALL_CMAKE_DIR}
+  FILE ${PROJECT_NAME}Targets.cmake)
+
+# Create the <package>Config.cmake.in
+configure_file(${CMAKE_SOURCE_DIR}/cmake/Config.cmake.in
+  "${PROJECT_CMAKE_FILES}/${PROJECT_NAME}Config.cmake" @ONLY)
+
+# Create the <package>ConfigVersion.cmake.in
+configure_file(${CMAKE_SOURCE_DIR}/cmake/ConfigVersion.cmake.in
+  "${PROJECT_CMAKE_FILES}/${PROJECT_NAME}ConfigVersion.cmake" @ONLY)
+
+# Install <package>Config.cmake and <package>ConfigVersion.cmake files
+install(FILES
+  "${PROJECT_CMAKE_FILES}/${PROJECT_NAME}Config.cmake"
+  "${PROJECT_CMAKE_FILES}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+
+# Uninstall targets
+configure_file("${CMAKE_SOURCE_DIR}/cmake/Uninstall.cmake.in"
+  "${PROJECT_CMAKE_FILES}/Uninstall.cmake"
+  IMMEDIATE @ONLY)
+add_custom_target(uninstall
+  COMMAND ${CMAKE_COMMAND} -P ${PROJECT_CMAKE_FILES}/Uninstall.cmake)

--- a/cmake/LibraryConfig.cmake
+++ b/cmake/LibraryConfig.cmake
@@ -1,0 +1,38 @@
+# Select library type
+set(_PN ${PROJECT_NAME})
+option(BUILD_SHARED_LIBS "Build ${_PN} as a shared library." ON)
+if(BUILD_SHARED_LIBS)
+  set(LIBRARY_TYPE SHARED)
+else()
+  set(LIBRARY_TYPE STATIC)
+endif()
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release'.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Target
+add_library(${LIBRARY_NAME} ${LIBRARY_TYPE} ${SOURCES} ${HEADERS})
+
+# Install library
+install(TARGETS ${LIBRARY_NAME}
+  EXPORT ${PROJECT_EXPORT}
+  RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT stlib
+  COMPONENT dev)
+
+# Create 'version.h'
+#configure_file(version.h.in
+#  "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
+#set(HEADERS ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+
+# Install headers
+install(FILES ${HEADERS}
+  DESTINATION "${INSTALL_INCLUDE_DIR}/${LIBRARY_FOLDER}" )

--- a/cmake/SetEnv.cmake
+++ b/cmake/SetEnv.cmake
@@ -1,0 +1,65 @@
+# Set PROJECT_NAME_UPPERCASE and PROJECT_NAME_LOWERCASE variables
+string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
+string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWERCASE)
+
+# Version variables
+set(MAJOR_VERSION 0)
+set(MINOR_VERSION 1)
+set(PATCH_VERSION 0)
+set(PROJECT_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
+
+# INSTALL_LIB_DIR
+set(INSTALL_LIB_DIR lib
+    CACHE PATH "Relative instalation path for libraries")
+
+# INSTALL_BIN_DIR
+set(INSTALL_BIN_DIR bin
+    CACHE PATH "Relative instalation path for executables")
+
+# INSTALL_INCLUDE_DIR
+set(INSTALL_INCLUDE_DIR include
+    CACHE PATH "Relative instalation path for header files")
+
+# INSTALL_CMAKE_DIR
+if(WIN32 AND NOT CYGWIN)
+  set(DEF_INSTALL_CMAKE_DIR CMake)
+else()
+  set(DEF_INSTALL_CMAKE_DIR lib/CMake/${PROJECT_NAME})
+endif()
+set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR}
+    CACHE PATH "Relative instalation path for CMake files")
+
+# Convert relative path to absolute path (needed later on)
+foreach(substring LIB BIN INCLUDE CMAKE)
+  set(var INSTALL_${substring}_DIR)
+  if(NOT IS_ABSOLUTE ${${var}})
+    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+  message(STATUS "${var}: "  "${${var}}")
+endforeach()
+
+# Set up include-directories
+include_directories(
+  "${PROJECT_SOURCE_DIR}"
+  "${PROJECT_BINARY_DIR}")
+
+# Library name (by default is the project name in lowercase)
+# Example: libfoo.so
+if(NOT LIBRARY_NAME)
+  set(LIBRARY_NAME ${PROJECT_NAME_LOWERCASE})
+endif()
+
+# Library folder name (by default is the project name in lowercase)
+# Example: #include <foo/foo.h>
+if(NOT LIBRARY_FOLDER)
+  set(LIBRARY_FOLDER ${PROJECT_NAME_LOWERCASE})
+endif()
+
+# The export set for all the targets
+set(PROJECT_EXPORT ${PROJECT_NAME}EXPORT)
+
+# Path of the CNake files generated
+set(PROJECT_CMAKE_FILES ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY})
+
+# The RPATH to be used when installing
+set(CMAKE_INSTALL_RPATH ${INSTALL_LIB_DIR})

--- a/cmake/Uninstall.cmake.in
+++ b/cmake/Uninstall.cmake.in
@@ -1,0 +1,68 @@
+#
+# Based on:
+#   http://www.cmake.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F
+#
+
+# 'delete_empty_folder' function
+function(delete_empty_folder DIR)
+  if(NOT EXISTS ${DIR})
+    return()
+  endif()
+
+  # check if folder is empty
+  file(GLOB RESULT "${DIR}/*")
+  list(LENGTH RESULT RES_LEN)
+  if(RES_LEN EQUAL 0)
+    message(STATUS "Delete empty folder ${DIR}")
+    file(REMOVE_RECURSE ${DIR})
+  else()
+    # message(STATUS "${DIR} is not empty! It won't be removed.")
+    # message(STATUS "FILES = ${RESULT}")
+  endif()
+endfunction(delete_empty_folder)
+
+# find 'install_manifest.txt'
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif()
+
+# remove files from 'install_manifest.txt'
+message(STATUS "")
+message(STATUS "Removing files from 'install_manifest.txt'")
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program("@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval)
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else()
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+
+  # create list of folders
+  get_filename_component(FOLDER ${file} DIRECTORY)
+  set(FOLDERS ${FOLDERS} ${FOLDER})
+endforeach(file)
+
+
+# remove empty folders
+message(STATUS "")
+message(STATUS "Removing empty folders")
+
+list(REMOVE_DUPLICATES FOLDERS)
+foreach(dir ${FOLDERS})
+#   message(STATUS ${dir})
+  delete_empty_folder(${dir})
+#   message(STATUS "")
+endforeach(dir)
+
+delete_empty_folder("@INSTALL_INCLUDE_DIR@")
+delete_empty_folder("@INSTALL_BIN_DIR@")
+delete_empty_folder("@INSTALL_LIB_DIR@/CMake")
+delete_empty_folder("@INSTALL_LIB_DIR@")
+message(STATUS "")

--- a/scg3/CMakeLists.txt
+++ b/scg3/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Set SOURCES variable
+file(GLOB SOURCES
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glew/src/*.c"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/detail/*.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src_ext/*.cpp")
+
+# Set HEADERS variable
+file(GLOB HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glew/include/GL/*.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/detail/*.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/detail/*.inl"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/ext/*.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/ext/*.inl"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/gtc/*.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/gtc/*.inl"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/gtx/*.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/gtx/*.inl"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/simd/*.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/glm/glm/*.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/extern/stb_image/*.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src_ext/*.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+include(${CMAKE_SOURCE_DIR}/cmake/LibraryConfig.cmake)

--- a/scg3/scg3.h
+++ b/scg3/scg3.h
@@ -218,7 +218,7 @@
  * \example scg3_table_scene_example.cpp
  */
 
-#include <src/scg_glew.h>
+#include "src/scg_glew.h"
 #include <GLFW/glfw3.h>
 
 #include "src/Animation.h"

--- a/scg3_example/CMakeLists.txt
+++ b/scg3_example/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable (scg3_example
     main.cpp)
 
+include_directories(${CMAKE_SOURCE_DIR}/scg3)
+
 target_link_libraries(scg3_example ${LIBRARY_NAME} ${LIBS})
 
 install(TARGETS scg3_example

--- a/scg3_example/CMakeLists.txt
+++ b/scg3_example/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable (scg3_example
+    main.cpp)
+
+target_link_libraries(scg3_example ${LIBRARY_NAME} ${LIBS})
+
+install(TARGETS scg3_example
+  RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin)

--- a/scg3_example/main.cpp
+++ b/scg3_example/main.cpp
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include <scg3.h>
+#include "scg3/scg3.h"
 
 using namespace scg;
 

--- a/scg3_example/main.cpp
+++ b/scg3_example/main.cpp
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include "scg3/scg3.h"
+#include <scg3.h>
 
 using namespace scg;
 


### PR DESCRIPTION
After several hours of fun I finally managed to build this project using CMake.

This branch adds the necessary files to build the library and example project from the command line (fixes #1).

Also it enables the global installation of the library into the linux system so that it can be used like any other library from the package manager.

I had to change the include statements in scg3.h and main.cpp to match the standard:
https://github.com/vahlers/scg3/compare/master...MarcusWichelmann:cmake-support?expand=1#diff-c8af6458dc46359f38428313b9537315R221
https://github.com/vahlers/scg3/compare/master...MarcusWichelmann:cmake-support?expand=1#diff-71b00e02a7a51eff57b8914b592558eeR30
I hope this doesn't break anything, but you should probably test if the project still works with eclipse.